### PR TITLE
task(ci): Set pnpm to publish without git checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish -r
+        run: pnpm -r publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
That's needed because the action checks out the tag ref, not main