### PR TITLE
Bugfix/59: Fix npm prepack commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "build:watch": "pnpm --parallel --filter=@janis.me/themed --filter=@janis.me/react-themed build:watch",
     "format": "prettier --write .",
     "lint": "eslint --flag unstable_config_lookup_from_file .",
-    "prepack": "pnpm -c exec ./prepack.sh",
     "publish:react-themed": "pnpm publish packages/react-themed --access public",
     "publish:themed": "pnpm publish packages/themed --access public",
     "test": "vitest"

--- a/packages/react-themed/package.json
+++ b/packages/react-themed/package.json
@@ -38,6 +38,7 @@
     "build:watch": "vite build --watch",
     "format": "prettier . --write",
     "prepublishOnly": "pnpm install && pnpm build",
+    "prepack": "pnpm -c exec ../scripts/prepack.sh",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@janis.me/scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/scripts/prepack.sh
+++ b/packages/scripts/prepack.sh
@@ -1,5 +1,5 @@
 # Find and replace all synlinks in the packages directory with their target files
-find ./packages -maxdepth 2 -type l -exec bash -c '
+find . -maxdepth 1 -type l -exec bash -c '
   for link do
     target=$(readlink -f "$link")
     if [ -f "$target" ]; then

--- a/packages/themed/package.json
+++ b/packages/themed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janis.me/themed",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "SCSS-native themes made simple",
   "keywords": [
@@ -41,6 +41,7 @@
     "build:watch": "vite build --watch",
     "format": "prettier . --write",
     "prepublishOnly": "pnpm install && pnpm build",
+    "prepack": "pnpm -c exec ../scripts/prepack.sh",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.3(@types/node@22.14.1)(rollup@4.40.0)(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(sass-embedded@1.86.3)(sass@1.86.3))
 
+  packages/scripts: {}
+
   packages/themed:
     devDependencies:
       '@janis.me/linter-config':


### PR DESCRIPTION
Closes #59, placing the prepack script next to the prePublishOnly scripts to properly replace the README symlinks